### PR TITLE
add utilities and CI to build and test notebook

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,21 +1,22 @@
+## Docker
+docker
+.dockerignore
+
+## Git
+.git
+.github
+.gitignore
+
 ## Make
-[Mm]akefile.config
+[Mm]akefile*
 downloads
 
-## Environment
+## Environments
 env
-venv
-
-## Conda
-environment.yml
 
 ## Node
-package.json
 package-lock.json
 node_modules
-
-## Docker
-#Dockerfile
 
 ## Celery
 celeryconfig*
@@ -31,27 +32,23 @@ celerybeat-schedule.*
 *.sqlite
 *.egg[s]
 *.egg-info
-*egg[s]
-__pycache__
+*egg[s]__pycache__
 .python_history
-.ipynb_checkpoints
-notebooks/*.json
 
 ## Unit test / Coverage reports
-*.log
-*.lock
 .cache
 .coverage
+coverage
 .pylint.d/
 .pytest_cache
 .tox
-coverage.xml
-coverage
-reports
 nosetests.xml
 unit_tests/testdata.json
-result[s].xml
+tests
+**/*.log
+**/*.lock
 testdata.json
+reports
 
 ## R
 *.Rhistory
@@ -60,9 +57,6 @@ testdata.json
 .project
 .pydevproject
 .settings
-
-## VS Code
-*.vscode
 
 ## PyCharm
 *.idea
@@ -76,6 +70,9 @@ testdata.json
 ## Sublime Text Editor
 *.sublime*
 
+# sphinx
+docs
+
 ## External Sources
 [Bb]uild
 src
@@ -84,19 +81,15 @@ src
 .ipynb_checkpoints
 
 ## gcc/fortran
-*.o
-*.a
-*.mod
-*.out
+**/*.o
+**/*.a
+**/*.mod
+**/*.out
+**/*.json
 
-## snappy
-esa-snap_sentinel_unix_6_0.sh
-response.varfile
+## Project local configurations
+!config/*.example
+config/*
 
-## project process results
-*.tif
-*.zip
-./workflow[s]
-
-## old project sources
+## Old project sources
 [Bb]in

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,39 @@
+---
+
+name: Bug Report
+about: Create a report to help us improve
+labels: triage/bug
+assignees: fmigneault
+
+---
+
+## Describe the bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+## How to Reproduce
+
+<!-- 
+Steps to reproduce the behavior:
+1. Deploy process with payload '...'
+2. Execute using payload '....'
+3. Result '....'
+4. Error message '...'
+5. etc.
+-->
+
+## Expected behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Context
+
+<!-- 
+    If applicable, add screenshots or drag-drop files to help explain your problem.
+    Also, please complete the following information.
+-->
+
+- OS: \[e.g. Linux|Windows] (if running locally)
+- Browser \[e.g. chrome, safari] (if running as a service)
+- Instance: \[ADES|EMS|Hybrid] and URL
+- Version \["1.2.3", see `/versions` endpoint]

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,27 @@
+---
+
+name: Feature Request
+about: Suggest an idea for this project
+labels: triage/feature
+assignees: fmigneault
+
+---
+
+## Description
+
+<!-- 
+
+- Is your feature request related to a missing implementation or functionality?
+- What is the expected solution or behaviour?
+- Describe alternative approaches you have considered.
+
+-->
+
+## References
+
+<!-- 
+Provide any external references or similar issue links here.
+
+- issue #<issue-number>
+- external https://link
+-->

--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -1,0 +1,41 @@
+---
+
+name: Security and Vulnerability Report
+about: Report a problem regarding security or identified vulnerabilities in code or dependencies.
+labels: triage/security
+assignees: fmigneault
+
+---
+
+## Describe the security issue
+
+<!-- A clear and concise description of what issue. -->
+
+## How to Reproduce
+
+<!-- 
+Steps to reproduce the issue:
+1. '...'
+2. '...'
+3. '...'
+-->
+
+## Known Solutions
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Additional References
+
+<!-- URL to related issues or CVE reports -->
+
+## Context
+
+<!-- 
+    If applicable, add screenshots or drag-drop files to help explain the problem.
+    Also, please provide any of the following information if relevant.
+
+- OS: \[e.g. Linux|Windows] (if running locally)
+- Browser \[e.g. chrome, safari] (if running as a service)
+- Instance: \[ADES|EMS|Hybrid] and URL
+- Version \["1.2.3", see `/versions` endpoint]
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
@@ -1,0 +1,25 @@
+---
+
+name: Pull Request
+about: Create a pull request to resolve issues or add new features.
+
+---
+
+## Changes
+
+- ...
+- ...
+- ...
+
+## Features and Fixes
+
+<!--
+- Fixes #\<issue number>
+- Relates to #\<issue number>
+-->
+
+## Checklist
+
+- [ ] Updated the [CHANGES.md](https://github.com/crim-ca/ncml2stac/blob/master/CHANGES.md) file.
+- [ ] Included fixes and related issue references in change logs.
+- [ ] Tests added/updated to validate fixes and/or new features.

--- a/.github/labeler-files.yml
+++ b/.github/labeler-files.yml
@@ -1,0 +1,34 @@
+# label rules used by PR labelers to match repository files
+# references:
+#   original: https://github.com/actions/labeler
+#   extended: https://github.com/ilyam8/periodic-pr-labeler
+
+## CI
+# all automation-related steps and files
+
+ci/operations:
+  - .*  # all '.<>' files
+  - ".github/**"
+  - MANIFEST.in
+  - hooks/**/*
+  - Makefile*
+  - Dockerfile*
+  - setup.*
+  - requirements*
+
+ci/doc:
+  - "*.rst"
+  - "*.md"
+  # ignore changelog as doc would almost always be tagged
+  - "!CHANGES.md"
+  - "*.example"
+  - LICENCE*
+  - docs/**/*
+
+ci/tests:
+  - tests/**/*
+
+## Triage
+
+triage/security:
+  - SECURITY.rst

--- a/.github/labeler-words.yml
+++ b/.github/labeler-words.yml
@@ -1,0 +1,32 @@
+# label rules used by labelers to match words
+# references:
+#   - https://github.com/github/issue-labeler
+
+
+feature/CWL:
+  - '(CWL|cwl)'
+  - 'workflow'
+
+feature/docker:
+  - '(Docker|docker)'
+
+triage/feature:
+  - 'feature'
+
+triage/bug:
+  - 'bug'
+
+ci/operations:
+  - 'ci'
+  - 'travis'
+  - 'github'
+
+ci/tests:
+  - 'coverage'
+  - 'functional test[s]*'
+  - 'unittest[s]*'
+
+ci/doc:
+  - 'documentation'
+  - 'readthedocs'
+  - 'rtd'

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,22 @@
+name: Greetings
+
+on: [pull_request, issues]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/first-interaction@v1
+      continue-on-error: true
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: >
+          Thanks for submitting an issue.
+
+          Make sure you have checked through existing/resolved issues to avoid duplicates.
+          Also, make sure you provide enough details for us to be able to replicate and understand the problem.
+        pr-message: >
+          Thanks for submitting a PR.
+
+          Make sure that you have added tests to validates new features or bugfixes.
+          Also, ensure that existing test suites are still working with the change using the commit test statuses.

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,24 @@
+# reference: https://github.com/github/issue-labeler
+
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened, edited]
+
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v3.2
+      with:
+        repo-token: ${{ github.token }}
+        configuration-path: .github/labeler-words.yml
+        enable-versioned-regex: 0
+        include-title: 1
+        include-body: 1
+        sync-labels: 0  # avoid unmatched regex to remove labels since they could be applied manually

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,43 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler/blob/master/README.md
+
+name: Pull Request Labeler
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  schedule:
+    - cron: '0 */12 * * *'
+
+jobs:
+  original-labeler:
+    # reference: https://github.com/actions/labeler
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        configuration-path: .github/labeler-files.yml
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+  extended-labeler:
+    # reference: https://github.com/ilyam8/periodic-pr-labeler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://docker.io/ilyam8/periodic-pr-labeler:latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LABEL_MAPPINGS_FILE: .github/labeler-files.yml
+  wip:
+    # reference: https://github.com/wip/action
+    # mark PRs with following keywords in the title: wip, work in progress, :construction:
+    # blocks merge of these branches using requirement:
+    #   [Settings > Branch > master > Protect matching branches > Require > check status with "WIP (action)"]
+    if: ${{ github.event_name == 'pull_request' }}  # WIP only works during PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wip/action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,55 @@
+# look for secrets pushed by mistake
+
+# NOTE: To fix problematic commits that got references to detected secrets, execute the following:
+# 1. Assuming the branch is built on top of master for a PR
+#     >> git rebase -i master
+# 2. Then, replace "pick" by "squash" for matched problematic commits
+#	 If this didn't work, more advanced edit of history commits needs to be applied.
+#	 Please refer to git interactive rebase documentation to do so.
+# 3. Finally re-run secrets analysis to validate that problems where fixed
+
+
+name: Secret Scan
+on:
+  - pull_request
+  - push
+
+jobs:
+  #trufflehog:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #  - uses: actions/checkout@master
+  #  - name: trufflehog-actions-scan
+  #    uses: edplato/trufflehog-actions-scan@master
+    #- uses: max/secret-scan@master
+    #  with:
+    #    repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  # ref: https://github.com/svdarren/secrets-workflow/blob/9633bc1195a1ca1d4d70415aa4eff6cf55d706de/.github/workflows/secrets.yml
+  gitleak:
+    name: gitleaks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Install dependencies
+        run: docker pull zricethezav/gitleaks
+      #- run: |
+      #    docker run --name=gitleaks --volume $GITHUB_WORKSPACE:/workspace/ \
+      #    -v --exclude-forks --redact --threads=1 --branch=$GITHUB_REF --repo-path=/workspace/
+      #- run: docker run --rm --name=gitleaks -v /tmp/:/code/ zricethezav/gitleaks -v --repo-path=/code/gitleaks
+      # @todo command is failing
+      #- run: gitleaks -v --exclude-forks --redact --threads=1 --branch=$GITHUB_REF --repo-path=$GITHUB_WORKSPACE
+
+      # FIXME: revert to original repo when (if) they ever consider the fix
+      #     https://github.com/eshork/gitleaks-action/pull/4
+      #     https://github.com/eshork/gitleaks-action/issues/3
+      #- uses: fmigneault/gitleaks-action@master
+      #- uses: zricethezav/gitleaks-action@master
+      - uses: gitleaks/gitleaks-action@v1.6.0  # see: https://github.com/gitleaks/gitleaks-action/issues/57
+      #- uses: eshork/gitleaks-action@v1.0.0
+      #- uses: CySeq/gitcret@v2
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ matrix.test-case != 'test-docker' }}
         # install package and dependencies directly,
         # skip sys/conda setup to use active python
-        run: make install-sys install-pkg install-pip install-raw install-dev version
+        run: make install-dev version
       - name: Display Packages
         # skip python setup if running with docker
         if: ${{ matrix.test-case != 'test-docker' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,15 +102,15 @@ jobs:
           hash -r
           env | sort
       - name: Run Tests
-        run: make stop ${{ matrix.test-case }}
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v2
-        if: ${{ success() && matrix.test-case == 'test-coverage-only' }}
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./reports/coverage.xml
-          fail_ci_if_error: true
-          verbose: true
+        run: make ${{ matrix.test-case }}
+#      - name: Upload coverage report
+#        uses: codecov/codecov-action@v2
+#        if: ${{ success() && matrix.test-case == 'test-coverage-only' }}
+#        with:
+#          token: ${{ secrets.CODECOV_TOKEN }}
+#          files: ./reports/coverage.xml
+#          fail_ci_if_error: true
+#          verbose: true
 
   deploy-docker:
     needs: tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,148 @@
+# run test suites
+
+name: Tests
+on:
+  - pull_request
+  - push
+  - release
+  - workflow_dispatch
+
+jobs:
+  # see: https://github.com/fkirc/skip-duplicate-actions
+  skip_duplicate:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip && ! contains(github.ref, 'refs/tags') }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: "same_content"
+          skip_after_successful_duplicate: "true"
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule", "release"]'
+
+  # see: https://github.com/actions/setup-python
+  tests:
+    # FIXME: https://github.com/fkirc/skip-duplicate-actions/issues/90
+    #   disable for now because the tests never run... somehow similar config works in Magpie...
+    # needs: skip_duplicate
+    # if: ${{ needs.skip_duplicate.outputs.should_skip != 'true' }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow-failure }}
+    env:
+      # override make command to install directly in active python
+      CONDA_CMD: ""
+      DOCKER_TEST_EXEC_ARGS: "-T"
+    services:
+      # Label used to access the service container
+      mongodb:
+        image: mongo:5.0  # DockerHub
+        ports:
+          - "27017:27017"
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10"]
+        allow-failure: [false]
+        test-case: [test-unit-only, test-func-only]
+        include:
+          # experimental python
+          - os: ubuntu-latest
+            python-version: "3.11"
+            allow-failure: true
+            test-case: test-notebook-only
+          # linter tests
+          - os: ubuntu-latest
+            python-version: "3.10"
+            allow-failure: false
+            test-case: check-all
+          # documentation build
+          - os: ubuntu-latest
+            python-version: "3.10"
+            allow-failure: false
+            test-case: docs
+          # coverage test
+          - os: ubuntu-latest
+            python-version: "3.10"
+            allow-failure: false
+            test-case: test-coverage-only
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - name: Setup Python
+        # skip python setup if running with docker
+        if: ${{ matrix.test-case != 'test-docker' }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: "${{ matrix.python-version }}"
+      - name: Parse Python Version
+        id: python-semver
+        run: |
+          echo "::set-output name=major:$(echo ${{ matrix.python-version }} | cut -d '.' -f 1)"
+          echo "::set-output name=minor:$(echo ${{ matrix.python-version }} | cut -d '.' -f 2)"
+      - uses: actions/cache@v3
+        name: Check Proj Lib Pre-Built in Cache
+        id: cache-proj
+        with:
+          # note: '22' is v8, '21' is v7
+          path: /tmp/proj-8.2.1/install
+          key: ${{ runner.os }}-python${{ matrix.python-version }}-proj
+      - name: Install Dependencies
+        # skip python setup if running with docker
+        if: ${{ matrix.test-case != 'test-docker' }}
+        # install package and dependencies directly,
+        # skip sys/conda setup to use active python
+        run: make install-sys install-pkg install-pip install-raw install-dev version
+      - name: Display Packages
+        # skip python setup if running with docker
+        if: ${{ matrix.test-case != 'test-docker' }}
+        run: pip freeze
+      #- name: Setup Environment Variables
+      #  uses: c-py/action-dotenv-to-setenv@v2
+      #  with:
+      #    env-file: ./ci/weaver.env
+      - name: Display Environment Variables
+        run: |
+          hash -r
+          env | sort
+      - name: Run Tests
+        run: make stop ${{ matrix.test-case }}
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v2
+        if: ${{ success() && matrix.test-case == 'test-coverage-only' }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./reports/coverage.xml
+          fail_ci_if_error: true
+          verbose: true
+
+  deploy-docker:
+    needs: tests
+    if: ${{ success() && (contains(github.ref, 'refs/tags') || github.ref == 'refs/heads/master') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - name: Get Tag Version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
+            echo "::set-output name=TAG_VERSION::latest"
+          else
+            echo "::set-output name=TAG_VERSION::${GITHUB_REF##*/}"
+          fi
+      - name: Build Docker
+        run: |
+          make DOCKER_REPO=pavics/weaver APP_VERSION=${{ steps.version.outputs.TAG_VERSION }} docker-info docker-build
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Push to DockerHub
+        run: |
+          make APP_VERSION=${{ steps.version.outputs.TAG_VERSION }} docker-push

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,15 +58,15 @@ jobs:
             allow-failure: false
             test-case: check-all
           # documentation build
-          - os: ubuntu-latest
-            python-version: "3.10"
-            allow-failure: false
-            test-case: docs
+#          - os: ubuntu-latest
+#            python-version: "3.10"
+#            allow-failure: false
+#            test-case: docs
           # coverage test
-          - os: ubuntu-latest
-            python-version: "3.10"
-            allow-failure: false
-            test-case: test-coverage-only
+#          - os: ubuntu-latest
+#            python-version: "3.10"
+#            allow-failure: false
+#            test-case: test-coverage-only
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,12 +34,6 @@ jobs:
       # override make command to install directly in active python
       CONDA_CMD: ""
       DOCKER_TEST_EXEC_ARGS: "-T"
-    services:
-      # Label used to access the service container
-      mongodb:
-        image: mongo:5.0  # DockerHub
-        ports:
-          - "27017:27017"
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.10"]
         allow-failure: [false]
-        test-case: [test-unit-only, test-func-only]
+        test-case: [test-only]
         include:
           # experimental python
           - os: ubuntu-latest

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,575 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=lxml.etree,
+                        schema_salad.sourceline,
+                        schema_salad.validate
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+# https://pylint.pycqa.org/en/latest/technical_reference/extensions.html
+load-plugins=pylint.extensions.docparams,
+             pylint.extensions.mccabe,
+             pylint_per_file_ignores
+
+# https://pylint.pycqa.org/en/latest/technical_reference/extensions.html#design-checker-options
+max-complexity = 24
+# FIXME: medium/lower-high complexity permitted, should focus toward <20 to facilitate testing and debugging
+
+# https://pylint.pycqa.org/en/latest/technical_reference/extensions.html#parameter-documentation-checker-options
+# allow unspecified items, but if the docstring is present, it should follow Sphinx format for documentation generation
+# see also 'disabled' W90XX warnings, we ignore only raised 'missing', but detect invalid documentation issues
+accept-no-param-doc = yes
+accept-no-raise-doc = yes
+accept-no-return-doc = yes
+accept-no-yields-doc = yes
+default-docstring-type = sphinx
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=C0111,missing-docstring,
+        C0206,consider-using-dict-items,
+        C0302,too-many-lines,
+        C0412,ungrouped-imports,
+        C0415,import-outside-toplevel,
+        C1801,len-as-condition,
+        E0015,unrecognized-option,
+        E0401,import-error,
+        E5110,django-not-configured,
+        R0022,useless-option-value,
+        R0201,no-self-use,
+        R0205,useless-object-inheritance,
+        # R0401 disabled to avoid unnecessary warnings on already handled circular imports
+        # See issue : https://github.com/PyCQA/pylint/issues/850
+        R0401,cyclic-import,
+        R0801,duplicate-code,
+        R0901,too-many-ancestors,
+        R0904,too-many-public-methods,
+        R0912,too-many-branches,
+        R0914,too-many-locals,
+        R0915,too-many-statements,
+        R1705,no-else-return,
+        R1710,inconsistent-return-statements,
+        R1711,useless-return,
+        R1721,unnecessary-comprehension,
+        R1725,super-with-arguments,
+        W0012,unknown-option-value,
+        W0108,unnecessary-lambda,
+        W0212,protected-access,
+        W0232,no-init,
+        W0235,useless-super-delegation,
+        W0613,unused-argument,
+        W0622,redefined-builtin,
+        W0640,cell-var-from-loop,
+        W0706,try-except-raise,
+        W0707,raise-missing-from,
+        W1508,invalid-envvar-default,
+        W9005,multiple-constructor-doc,
+        W9006,missing-raises-doc,
+        W9011,missing-return-doc,
+        W9012,missing-return-type-doc,
+        W9013,missing-yield-doc,
+        W9014,missing-yield-type-doc,
+        W9015,missing-param-doc,
+        W9016,missing-type-doc
+
+# note: (C0412, ungrouped-imports) is managed via isort tool, ignore false positives
+
+per-file-ignores =
+  tests/*:R1729
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and MSVC (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=colorized
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=10
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=cornice.Service.*,
+                  cornice.service.Service.*,
+                  str.value
+# note: 'str.value' is flagged by Enum members defined with strings
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,str,cornice.Service,cornice.service.Service
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+#ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=yes
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, `new` is for `{}` formatting,and `fstr` is for f-strings.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+# plugin:
+#   https://pypi.python.org/pypi/pylint-quotes
+string-quote=double
+triple-quote=double
+docstring-quote=double
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+# - Ignore HTTP(S) URL
+# - Ignore RST references (e.g.: long method path)
+# Both could be indented (e.g.: within a docstring, class, function, etc.)
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$|^\s*\:\w+\:\`\S+\`$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,j,k,v,kv,ex,x,y,z,f,h,db,kw,dt,q,ns,id,s3,to,_
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=HACK
+## FIXME,TODO,
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=10
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=posixpath,typing,typing_extensions
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant,cornice_swagger,cwltool,cwt,docker
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=20
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=20
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=20
+
+# Maximum number of branch for function / method body.
+max-branches=20
+
+# Maximum number of locals for function / method body.
+max-locals=20
+
+# Maximum number of parents for a class (see R0901).
+max-parents=10
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=20
+
+# Maximum number of statements in function / method body.
+max-statements=100
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=builtins.BaseException

--- a/.remarkignore
+++ b/.remarkignore
@@ -1,0 +1,13 @@
+# To save time scanning
+.idea/
+.vscode/
+*.egg-info/
+downloads/
+env/
+
+# actual items to ignore
+.pytest_cache/
+node_modules/
+docs/_build/
+docs/build/
+reports/

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,25 @@
+{
+  "settings": {
+    "bullet": "-",
+    "fence": "`",
+    "fences": "true",
+    "listItemIndent": "mixed",
+    "incrementListMarker": "true",
+    "resourceLink": "true",
+    "rule": "-"
+  },
+  "plugins": [
+    "remark-gfm",
+    "remark-preset-lint-markdown-style-guide",
+    "remark-preset-lint-recommended",
+    "remark-lint-list-item-content-indent",
+    "remark-lint-checkbox-content-indent",
+    ["remark-lint-heading-style", "consistent"],
+    ["lint-fenced-code-marker", "`"],
+    ["lint-list-item-indent", "mixed"],
+    ["lint-maximum-line-length", 120],
+    ["lint-ordered-list-marker-style", "."],
+    ["lint-ordered-list-marker-value", "ordered"],
+    ["lint-unordered-list-marker-style", "consistent"]
+  ]
+}

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,14 @@
+# Safety Security and License Configuration file
+# https://docs.safetycli.com/safety-2/safety-cli-2-scanner/policy-file
+security:
+  # A severity number between 0 and 10. Some helpful reference points: 9=ignore all vulnerabilities except CRITICAL severity. 7=ignore all vulnerabilities except CRITICAL
+  ignore-cvss-severity-below: 0
+  # True or False. We recommend you set this to False.
+  ignore-cvss-unknown-severity: False
+  # Suppress non-zero exit codes when vulnerabilities are found. Enable this in pipelines and CI/CD processes if you want to pass builds that have vulnerabilities
+  continue-on-vulnerability-error: False
+  # Here you can list multiple specific vulnerabilities you want to ignore (optionally for a time period)
+  ignore-vulnerabilities: {}
+    # <id>:
+    #   reason: ''
+    #   expires: ''

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,12 @@
+{
+  "extends": "stylelint-config-standard",
+  "ignoreFiles": ["docs/_build/**", "docs/build/**"],
+  "rules": {
+    "block-no-empty": null,
+    "color-no-invalid-hex": true,
+    "color-hex-case": "upper",
+    "color-hex-length": "long",
+    "indentation": [4],
+    "no-descending-specificity": null
+  }
+}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,12 @@ Changes
 [Unreleased](https://github.com/crim-ca/ncml2stac/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+- Add CI utilities to test the Jupyter Notebook, build and deploy the resulting Docker image.
+- Add CI configurations for tagging and defining various GitHub control flow tools.
+- Remove irrelevant `Makefile` targets and add useful ones for this repository.
+- Update `README` documentation with adjusted directive with real commands.
+- Update `ncml2stac` notebook to display a valid STAC Item JSON as output.
+- Fix Docker image generation causing `IndentError` due to `TYPE_CHECKING` directive only using `ipython2cwl` imports.
 
 [0.0.1](https://github.com/crim-ca/ncml2stac/tree/0.0.1) (2023-09-28)
 ------------------------------------------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -339,6 +339,7 @@ clean-src:		## remove all *.pyc files
 	@echo "Removing python artifacts..."
 	@-find "$(APP_ROOT)" -type f -name "*.pyc" -exec rm {} \;
 	@-rm -rf ./build
+	@-rm -rf ./src
 
 .PHONY: clean-test
 clean-test:		## remove files created by tests and coverage analysis

--- a/Makefile
+++ b/Makefile
@@ -222,23 +222,23 @@ conda-env-export:		## export the conda environment
 
 ## -- Build targets ------------------------------------------------------------------------------------------------- ##
 
-.PHONY: install
-install: install-all    ## alias for 'install-all' target
-
 .PHONY: install-run
 install-run: conda-install install-sys install-pkg install-raw 	## install requirements and application to run locally
 
 .PHONY: install-all
 install-all: conda-install install-sys install-pkg install-pip install-dev  ## install application with all dependencies
 
+.PHONY: install
+install: install-pip install-pkg   ## alias for 'install-all' target
+
 .PHONY: install-doc
-install-doc: install-pip	## install documentation dependencies
+install-doc: install	## install documentation dependencies
 	@echo "Installing development packages with pip..."
 	@bash -c '$(CONDA_CMD) pip install $(PIP_XARGS) -r "$(APP_ROOT)/requirements-doc.txt"'
 	@echo "Install with pip complete. Run documentation generation with 'make docs' target."
 
 .PHONY: install-dev
-install-dev: install-pip	## install development and test dependencies
+install-dev: install	## install development and test dependencies
 	@echo "Installing development packages with pip..."
 	@bash -c '$(CONDA_CMD) pip install $(PIP_XARGS) -r "$(APP_ROOT)/requirements-dev.txt"'
 	@echo "Install with pip complete. Test service with 'make test*' variations."

--- a/README.md
+++ b/README.md
@@ -1,45 +1,44 @@
 # NCML to STAC
 
-[![version](https://img.shields.io/github/v/tag/crim-ca/ncml2stac?label=latest%20version)](
-https://github.com/crim-ca/ncml2stac/tree/0.0.1
-)
+[![version](https://img.shields.io/github/v/tag/crim-ca/ncml2stac?label=latest%20version)](https://github.com/crim-ca/ncml2stac/tree/0.0.1)
 
 Converts a NCML XML with NetCDF file reference to a STAC Item JSON definition.
 
 ## CWL Application Package for Weaver OGC API - Processes
 
 This project can be directly converted to a [Common Workflow Language (CWL)](https://www.commonwl.org/) definition
-to generate a standalone and containerized *Application Package*. This package can then be deployed on 
+to generate a standalone and containerized *Application Package*. This package can then be deployed on
 a *OGC API - Processes* capable server that supports *Part 2: Deploy, Replace, Undeploy (DRU)* extension, such
 as [Weaver](https://github.com/crim-ca/weaver).
 
 To do so, use the following steps.
 
-1. Generate a *CWL* corresponding to the Notebook. This will also build a Docker image with all necessary dependencies.
+1.  Generate a *CWL* corresponding to the Notebook. This will also build a Docker image with all necessary dependencies.
 
     ```shell
     jupyter-repo2cwl "https://github.com/crim-ca/ncml2sta" -o /tmp
     ```
+
     (replace the Git repository URL by the path if the clone locally)
 
-2. (*optional*) Push the generated Docker image to a Docker registry.
+2.  (*optional*) Push the generated Docker image to a Docker registry.
 
-   Look for the output from the previous `jupyter-repo2cwl` command to find the generated `dockerImageId`.
-   Alternatively, look for the Docker tag applied for `DockerRequirement` in `/tmp/notebooks_ncml2stac.cwl`.
+    Look for the output from the previous `jupyter-repo2cwl` command to find the generated `dockerImageId`.
+    Alternatively, look for the Docker tag applied for `DockerRequirement` in `/tmp/notebooks_ncml2stac.cwl`.
 
-   By default, the generated *CWL* will use `dockerImageId` under the `DockerRequirement`.
-   This means that *CWL* will expect to run the built Docker image directly **without** pulling it.
-   If the remote *Weaver* server is expected to already have the Docker image in cache
-   (i.e.: `docker pull` ran manually on the server beforehand), then the tag under `dockerImageId` should be set
-   by the server administrator for that pulled image on the server.
+    By default, the generated *CWL* will use `dockerImageId` under the `DockerRequirement`.
+    This means that *CWL* will expect to run the built Docker image directly **without** pulling it.
+    If the remote *Weaver* server is expected to already have the Docker image in cache
+    (i.e.: `docker pull` ran manually on the server beforehand), then the tag under `dockerImageId` should be set
+    by the server administrator for that pulled image on the server.
 
-   If a different tag is used for pushing the Docker image to a Docker registry, and that it is expected that
-   the *Weaver* server will automatically pull that image before running it, then the `DockerRequirement` will
-   need to be adjusted accordingly with the adjusted Docker repository and image tag location.
-   Specifically, the `dockerImageId` needs to be **replaced** by `dockerPull` using the selected 
-   registry location (e.g.: `<docker-registry>/<org>/<image:tag>`).
+    If a different tag is used for pushing the Docker image to a Docker registry, and that it is expected that
+    the *Weaver* server will automatically pull that image before running it, then the `DockerRequirement` will
+    need to be adjusted accordingly with the adjusted Docker repository and image tag location.
+    Specifically, the `dockerImageId` needs to be **replaced** by `dockerPull` using the selected
+    registry location (e.g.: `<docker-registry>/<org>/<image:tag>`).
 
-3. Deploy the process in *Weaver* using the *CWL* file.
+3.  Deploy the process in *Weaver* using the *CWL* file.
 
     ```shell
     weaver deploy -u http://example.com/weaver -i ncml2stac --cwl /tmp/notebooks_ncml2stac.cwl
@@ -47,13 +46,13 @@ To do so, use the following steps.
 
 ## References
 
-- NCML XML to STAC Item JSON conversion logic:
-  - https://github.com/crim-ca/stac-populator
+-   NCML XML to STAC Item JSON conversion logic:
+    - [https://github.com/crim-ca/stac-populator](https://github.com/crim-ca/stac-populator)
 
-- Jupyter Notebook to CWL using `jupyter-repo2cwl`:
-  - https://github.com/common-workflow-lab/ipython2cwl
-  - https://ipython2cwl.readthedocs.io/en/latest/
+-   Jupyter Notebook to CWL using `jupyter-repo2cwl`:
+    - [https://github.com/common-workflow-lab/ipython2cwl](https://github.com/common-workflow-lab/ipython2cwl)
+    - [https://ipython2cwl.readthedocs.io/en/latest/](https://ipython2cwl.readthedocs.io/en/latest/)
 
-- Git Repository to Docker with Jupyter Notebook using `jupyter-repo2docker`:
-  - https://github.com/jupyterhub/repo2docker
-  - https://repo2docker.readthedocs.io/
+-   Git Repository to Docker with Jupyter Notebook using `jupyter-repo2docker`:
+    - [https://github.com/jupyterhub/repo2docker](https://github.com/jupyterhub/repo2docker)
+    - [https://repo2docker.readthedocs.io/](https://repo2docker.readthedocs.io/)

--- a/README.md
+++ b/README.md
@@ -15,27 +15,40 @@ as [Weaver](https://github.com/crim-ca/weaver).
 
 To do so, use the following steps.
 
-1. Generate a CWL corresponding to the Notebook. This will also build a Docker image with all necessary dependencies.
+1. Generate a *CWL* corresponding to the Notebook. This will also build a Docker image with all necessary dependencies.
 
     ```shell
     jupyter-repo2cwl "https://github.com/crim-ca/ncml2sta" -o /tmp
     ```
+    (replace the Git repository URL by the path if the clone locally)
 
-2. Push the generated Docker image to a Docker registry.
+2. (*optional*) Push the generated Docker image to a Docker registry.
 
-   Look for the output from the previous `jupyter-repo2cwl` command.
+   Look for the output from the previous `jupyter-repo2cwl` command to find the generated `dockerImageId`.
    Alternatively, look for the Docker tag applied for `DockerRequirement` in `/tmp/notebooks_ncml2stac.cwl`.
 
-   If a different tag is used for pushing the Docker image, the `DockerRequirement` will need to be adjusted
-   accordingly with the adjusted Docker repository and image tag location.
+   By default, the generated *CWL* will use `dockerImageId` under the `DockerRequirement`.
+   This means that *CWL* will expect to run the built Docker image directly **without** pulling it.
+   If the remote *Weaver* server is expected to already have the Docker image in cache
+   (i.e.: `docker pull` ran manually on the server beforehand), then the tag under `dockerImageId` should be set
+   by the server administrator for that pulled image on the server.
 
-3. Deploy the process in Weaver.
+   If a different tag is used for pushing the Docker image to a Docker registry, and that it is expected that
+   the *Weaver* server will automatically pull that image before running it, then the `DockerRequirement` will
+   need to be adjusted accordingly with the adjusted Docker repository and image tag location.
+   Specifically, the `dockerImageId` needs to be **replaced** by `dockerPull` using the selected 
+   registry location (e.g.: `<docker-registry>/<org>/<image:tag>`).
+
+3. Deploy the process in *Weaver* using the *CWL* file.
 
     ```shell
     weaver deploy -u http://example.com/weaver -i ncml2stac --cwl /tmp/notebooks_ncml2stac.cwl
     ```
 
 ## References
+
+- NCML XML to STAC Item JSON conversion logic:
+  - https://github.com/crim-ca/stac-populator
 
 - Jupyter Notebook to CWL using `jupyter-repo2cwl`:
   - https://github.com/common-workflow-lab/ipython2cwl

--- a/notebooks/ncml2stac.ipynb
+++ b/notebooks/ncml2stac.ipynb
@@ -38,25 +38,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 22,
    "outputs": [],
    "source": [
     "# NOTE:\n",
-    "#  If using indented code block here (eg: 'if TYPE_CHECKING:'), it is important to have other things than 'ipython2cwl' imports.\n",
-    "#  When ported into the generated python script, imports from 'ipython2cwl' are removed, which can cause syntax/indent errors.\n",
+    "#  If using indented code block here (eg: 'if TYPE_CHECKING:'),\n",
+    "#  it is important to have other things than 'ipython2cwl' imports.\n",
+    "#  When ported into the generated python script, imports from 'ipython2cwl' are removed,\n",
+    "#  which can cause syntax/indent errors.\n",
     "try:\n",
-    "    from typing import Optional  # to make optional inputs, define types like so: 'Optional[CWL<type>Input]'\n",
+    "    # to make optional inputs, define types like so: 'Optional[CWL<type>Input]'\n",
+    "    from typing import Optional  # noqa  # pylint: disable=W0611\n",
     "    from ipython2cwl.iotypes import CWLFilePathInput, CWLFilePathOutput\n",
     "except ImportError:\n",
     "    pass  # ignore explicit typing definitions if modules were not installed (CWL conversion still works)\n",
     "\n",
-    "input_ncml: \"CWLFilePathInput\" = \"https://raw.githubusercontent.com/crim-ca/stac-populator/ce268cdcde6030b3813f858ab1342b7cafa463e3/tests/data/o3_Amon_GFDL-ESM4_historical_r1i1p1f1_gr1_185001-194912.xml\""
+    "input_ncml: \"CWLFilePathInput\" = (\n",
+    "    \"https://raw.githubusercontent.com/crim-ca/stac-populator/ce268cdcde6030b3813f858ab1342b7cafa463e3/\"\n",
+    "    \"tests/data/o3_Amon_GFDL-ESM4_historical_r1i1p1f1_gr1_185001-194912.xml\"\n",
+    ")"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-28T16:31:11.120473225Z",
-     "start_time": "2023-09-28T16:31:11.106421052Z"
+     "end_time": "2023-09-28T20:04:51.082621656Z",
+     "start_time": "2023-09-28T20:04:51.038367970Z"
     }
    },
    "id": "61f43c81dc3aa6c2"
@@ -68,7 +74,9 @@
     "\n",
     "This code assumes that the following reference and all its dependencies are installed:\n",
     "\n",
-    "[https://github.com/crim-ca/stac-populator/tree/weaver-repo2cwl-ncml2sta](https://github.com/crim-ca/stac-populator/tree/weaver-repo2cwl-ncml2stac)\n",
+    "[https://github.com/crim-ca/stac-populator/tree/weaver-repo2cwl-ncml2sta](\n",
+    "https://github.com/crim-ca/stac-populator/tree/weaver-repo2cwl-ncml2stac\n",
+    ")\n",
     "\n",
     "Run `make install` to have them automatically installed."
    ],
@@ -127,13 +135,13 @@
     "import json\n",
     "import tempfile\n",
     "from datetime import datetime, date\n",
-    "from dateutil.parser import parse as dt_parse\n",
     "from enum import Enum\n",
     "\n",
     "import numpy as np\n",
     "import requests\n",
     "import xncml\n",
     "import pystac\n",
+    "from dateutil.parser import parse as dt_parse\n",
     "from pystac.extensions import datacube\n",
     "from pydantic.networks import Url\n",
     "from shapely.geometry.polygon import Polygon\n",
@@ -141,7 +149,7 @@
     "import pyessv\n",
     "pyessv.init()\n",
     "\n",
-    "from STACpopulator.extensions import cmip6"
+    "from STACpopulator.extensions import cmip6  # pylint: disable=C0413  # requires other module init to avoid ImportError"
    ],
    "metadata": {
     "collapsed": false,
@@ -350,7 +358,10 @@
     "if not (input_ncml.startswith(\"/\") or input_ncml.startswith(\"file:///\")):\n",
     "    resp = requests.get(input_ncml, headers={\"Accept\": \"text/xml, application/xml\"}, timeout=5)\n",
     "    if not resp.status_code == 200 and resp.text.startswith(\"<?xml\"):\n",
-    "        raise ValueError(f\"Could not retrieve NCML XML file contents from [{input_ncml}]. Error: [{resp.status_code}]: {resp.text!s}\")\n",
+    "        raise ValueError(\n",
+    "            f\"Could not retrieve NCML XML file contents from [{input_ncml}].\"\n",
+    "            f\"Error: [{resp.status_code}]: {resp.text!s}\"\n",
+    "        )\n",
     "    with tempfile.NamedTemporaryFile(mode=\"w\", encoding=\"utf-8\", delete=False) as tmp_file:\n",
     "        tmp_file.write(resp.text)\n",
     "        input_ncml = tmp_file.name\n",

--- a/notebooks/ncml2stac.ipynb
+++ b/notebooks/ncml2stac.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 28,
    "outputs": [],
    "source": [
     "# NOTE:\n",
@@ -61,8 +61,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-28T20:04:51.082621656Z",
-     "start_time": "2023-09-28T20:04:51.038367970Z"
+     "end_time": "2023-09-28T22:12:35.383018674Z",
+     "start_time": "2023-09-28T22:12:35.132491964Z"
     }
    },
    "id": "61f43c81dc3aa6c2"
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 29,
    "outputs": [
     {
      "name": "stdout",
@@ -96,9 +96,9 @@
       "Cloning into '/home/francis/.esdoc/pyessv-archive'...\r\n",
       "remote: Enumerating objects: 63068, done.\u001B[K\r\n",
       "remote: Counting objects: 100% (1557/1557), done.\u001B[K\r\n",
-      "remote: Compressing objects: 100% (476/476), done.\u001B[K (300/476)\u001B[Kremote: Compressing objects:  86% (410/476)\u001B[K\r\n",
-      "remote: Total 63068 (delta 1258), reused 1327 (delta 1070), pack-reused 61511\u001B[Ks:  26% (16398/63068), 1.35 MiB | 867.00 KiB/sReceiving objects:  28% (17660/63068), 1.35 MiB | 867.00 KiB/sReceiving objects:  31% (19552/63068), 1.35 MiB | 867.00 KiB/sReceiving objects:  35% (22074/63068), 1.35 MiB | 867.00 KiB/sReceiving objects:  43% (27120/63068), 1.35 MiB | 867.00 KiB/sReceiving objects:  49% (30904/63068), 1.35 MiB | 867.00 KiB/sReceiving objects:  56% (35319/63068), 2.59 MiB | 1.24 MiB/sReceiving objects:  63% (39733/63068), 2.59 MiB | 1.24 MiB/sReceiving objects:  66% (41625/63068), 2.59 MiB | 1.24 MiB/sReceiving objects:  69% (43517/63068), 2.59 MiB | 1.24 MiB/sReceiving objects:  76% (47932/63068), 2.59 MiB | 1.24 MiB/sReceiving objects:  81% (51086/63068), 2.59 MiB | 1.24 MiB/sReceiving objects:  83% (52347/63068), 4.36 MiB | 1.67 MiB/sReceiving objects:  85% (53608/63068), 4.36 MiB | 1.67 MiB/sReceiving objects:  97% (61176/63068), 4.36 MiB | 1.67 MiB/sReceiving objects:  99% (62438/63068), 4.36 MiB | 1.67 MiB/s\r\n",
-      "Receiving objects: 100% (63068/63068), 6.06 MiB | 2.03 MiB/s, done.\r\n",
+      "remote: Compressing objects: 100% (476/476), done.\u001B[K\r\n",
+      "remote: Total 63068 (delta 1258), reused 1327 (delta 1070), pack-reused 61511\u001B[K\r\n",
+      "Receiving objects: 100% (63068/63068), 6.06 MiB | 2.94 MiB/s, done.\r\n",
       "Resolving deltas: 100% (60270/60270), done.\r\n",
       "\r\n",
       "Local identity for pyessv-archive set to \"Francis Charette Migneault <francis.charette.migneault@gmail.com>\"\r\n"
@@ -113,21 +113,21 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-28T16:31:16.902705889Z",
-     "start_time": "2023-09-28T16:31:11.106550733Z"
+     "end_time": "2023-09-28T22:12:40.467006089Z",
+     "start_time": "2023-09-28T22:12:35.228660929Z"
     }
    },
    "id": "f10d85e12b47da43"
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 30,
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2023-09-28 17:35:19.776139 [INFO] :: PYESSV :: Loading vocabularies from /home/francis/.esdoc/pyessv-archive ... please wait\n"
+      "2023-09-28 22:12:40.483392 [INFO] :: PYESSV :: Loading vocabularies from /home/francis/.esdoc/pyessv-archive ... please wait\n"
      ]
     }
    ],
@@ -154,15 +154,15 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-28T17:35:20.176850296Z",
-     "start_time": "2023-09-28T17:35:19.792250122Z"
+     "end_time": "2023-09-28T22:12:41.260193681Z",
+     "start_time": "2023-09-28T22:12:40.469074021Z"
     }
    },
    "id": "f68ea4339c5e4a9d"
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 31,
    "outputs": [
     {
      "name": "stdout",
@@ -349,7 +349,9 @@
       "    <ncml:attribute name=\"missing_value\" type=\"double\" value=\"1.0E20\" />\n",
       "    <ncml:attribute name=\"_CoordinateAxisType\" value=\"Lon\" />\n",
       "  </ncml:variable>\n",
-      "</ncml:netcdf>\n"
+      "</ncml:netcdf>\n",
+      "\n",
+      "\n"
      ]
     }
    ],
@@ -373,15 +375,15 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-28T17:35:22.030164524Z",
-     "start_time": "2023-09-28T17:35:22.021956770Z"
+     "end_time": "2023-09-28T22:12:41.417055537Z",
+     "start_time": "2023-09-28T22:12:41.181965479Z"
     }
    },
    "id": "4fc2f66493dc56c5"
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 32,
    "outputs": [],
    "source": [
     "ds = xncml.Dataset(input_ncml)\n",
@@ -460,8 +462,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-28T17:35:25.445079640Z",
-     "start_time": "2023-09-28T17:35:25.350961204Z"
+     "end_time": "2023-09-28T22:12:41.474936053Z",
+     "start_time": "2023-09-28T22:12:41.427458731Z"
     }
    },
    "id": "299946ccd58e2efc"
@@ -478,7 +480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 33,
    "outputs": [
     {
      "name": "stdout",
@@ -718,8 +720,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-28T17:35:28.171687505Z",
-     "start_time": "2023-09-28T17:35:28.113990343Z"
+     "end_time": "2023-09-28T22:12:41.484610088Z",
+     "start_time": "2023-09-28T22:12:41.456950960Z"
     }
    },
    "id": "4eeb52c23edccb31"
@@ -736,7 +738,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 34,
    "outputs": [],
    "source": [
     "# NOTE:\n",
@@ -749,8 +751,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-28T17:06:28.432647458Z",
-     "start_time": "2023-09-28T17:06:28.386642425Z"
+     "end_time": "2023-09-28T22:12:41.544969400Z",
+     "start_time": "2023-09-28T22:12:41.477862056Z"
     }
    },
    "id": "e4fa98fcad8b5556"

--- a/notebooks/ncml2stac.ipynb
+++ b/notebooks/ncml2stac.ipynb
@@ -760,7 +760,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "name": "ncml2stac",
+   "name": "python3",
    "language": "python",
    "display_name": "ncml2stac"
   },

--- a/notebooks/ncml2stac.ipynb
+++ b/notebooks/ncml2stac.ipynb
@@ -10,6 +10,7 @@
     "```shell\n",
     "jupyter-repo2cwl \"https://github.com/crim-ca/ncml2sta\" -o /tmp\n",
     "```\n",
+    "(replace the Git repository URL by the path if the clone locally)\n",
     "\n",
     "It can then be deployed in *Weaver* using the CLI:\n",
     "\n",
@@ -37,21 +38,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "outputs": [],
    "source": [
-    "from typing import TYPE_CHECKING\n",
-    "\n",
-    "if TYPE_CHECKING:\n",
+    "# NOTE:\n",
+    "#  If using indented code block here (eg: 'if TYPE_CHECKING:'), it is important to have other things than 'ipython2cwl' imports.\n",
+    "#  When ported into the generated python script, imports from 'ipython2cwl' are removed, which can cause syntax/indent errors.\n",
+    "try:\n",
+    "    from typing import Optional  # to make optional inputs, define types like so: 'Optional[CWL<type>Input]'\n",
     "    from ipython2cwl.iotypes import CWLFilePathInput, CWLFilePathOutput\n",
+    "except ImportError:\n",
+    "    pass  # ignore explicit typing definitions if modules were not installed (CWL conversion still works)\n",
     "\n",
     "input_ncml: \"CWLFilePathInput\" = \"https://raw.githubusercontent.com/crim-ca/stac-populator/ce268cdcde6030b3813f858ab1342b7cafa463e3/tests/data/o3_Amon_GFDL-ESM4_historical_r1i1p1f1_gr1_185001-194912.xml\""
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-27T22:12:55.559741225Z",
-     "start_time": "2023-09-27T22:12:55.348033103Z"
+     "end_time": "2023-09-28T16:31:11.120473225Z",
+     "start_time": "2023-09-28T16:31:11.106421052Z"
     }
    },
    "id": "61f43c81dc3aa6c2"
@@ -63,7 +68,9 @@
     "\n",
     "This code assumes that the following reference and all its dependencies are installed:\n",
     "\n",
-    "https://github.com/crim-ca/stac-populator/tree/weaver-repo2cwl-ncml2stac"
+    "[https://github.com/crim-ca/stac-populator/tree/weaver-repo2cwl-ncml2sta](https://github.com/crim-ca/stac-populator/tree/weaver-repo2cwl-ncml2stac)\n",
+    "\n",
+    "Run `make install` to have them automatically installed."
    ],
    "metadata": {
     "collapsed": false
@@ -72,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "outputs": [
     {
      "name": "stdout",
@@ -80,10 +87,10 @@
      "text": [
       "Cloning into '/home/francis/.esdoc/pyessv-archive'...\r\n",
       "remote: Enumerating objects: 63068, done.\u001B[K\r\n",
-      "remote: Counting objects: 100% (1557/1557), done.\u001B[K6/1557)\u001B[K\r\n",
-      "remote: Compressing objects: 100% (476/476), done.\u001B[K\r\n",
-      "remote: Total 63068 (delta 1258), reused 1327 (delta 1070), pack-reused 61511\u001B[Ks:  27% (17029/63068), 1.33 MiB | 1.31 MiB/sReceiving objects:  29% (18290/63068), 1.33 MiB | 1.31 MiB/sReceiving objects:  33% (20813/63068), 1.33 MiB | 1.31 MiB/sReceiving objects:  36% (22705/63068), 1.33 MiB | 1.31 MiB/sReceiving objects:  39% (24597/63068), 1.33 MiB | 1.31 MiB/sReceiving objects:  42% (26489/63068), 2.12 MiB | 1.38 MiB/sReceiving objects:  48% (30273/63068), 2.12 MiB | 1.38 MiB/sReceiving objects:  52% (32796/63068), 2.12 MiB | 1.38 MiB/sReceiving objects:  57% (35949/63068), 2.12 MiB | 1.38 MiB/sReceiving objects:  61% (38912/63068), 2.12 MiB | 1.38 MiB/sReceiving objects:  64% (40364/63068), 2.96 MiB | 1.45 MiB/sReceiving objects:  71% (44779/63068), 2.96 MiB | 1.45 MiB/sReceiving objects:  78% (49194/63068), 2.96 MiB | 1.45 MiB/sReceiving objects:  80% (50455/63068), 2.96 MiB | 1.45 MiB/sReceiving objects:  82% (51716/63068), 2.96 MiB | 1.45 MiB/sReceiving objects:  84% (52978/63068), 4.29 MiB | 1.68 MiB/sReceiving objects:  88% (55500/63068), 4.29 MiB | 1.68 MiB/sReceiving objects:  93% (58654/63068), 4.29 MiB | 1.68 MiB/sReceiving objects:  98% (61807/63068), 4.29 MiB | 1.68 MiB/s\r\n",
-      "Receiving objects: 100% (63068/63068), 6.06 MiB | 2.02 MiB/s, done.\r\n",
+      "remote: Counting objects: 100% (1557/1557), done.\u001B[K\r\n",
+      "remote: Compressing objects: 100% (476/476), done.\u001B[K (300/476)\u001B[Kremote: Compressing objects:  86% (410/476)\u001B[K\r\n",
+      "remote: Total 63068 (delta 1258), reused 1327 (delta 1070), pack-reused 61511\u001B[Ks:  26% (16398/63068), 1.35 MiB | 867.00 KiB/sReceiving objects:  28% (17660/63068), 1.35 MiB | 867.00 KiB/sReceiving objects:  31% (19552/63068), 1.35 MiB | 867.00 KiB/sReceiving objects:  35% (22074/63068), 1.35 MiB | 867.00 KiB/sReceiving objects:  43% (27120/63068), 1.35 MiB | 867.00 KiB/sReceiving objects:  49% (30904/63068), 1.35 MiB | 867.00 KiB/sReceiving objects:  56% (35319/63068), 2.59 MiB | 1.24 MiB/sReceiving objects:  63% (39733/63068), 2.59 MiB | 1.24 MiB/sReceiving objects:  66% (41625/63068), 2.59 MiB | 1.24 MiB/sReceiving objects:  69% (43517/63068), 2.59 MiB | 1.24 MiB/sReceiving objects:  76% (47932/63068), 2.59 MiB | 1.24 MiB/sReceiving objects:  81% (51086/63068), 2.59 MiB | 1.24 MiB/sReceiving objects:  83% (52347/63068), 4.36 MiB | 1.67 MiB/sReceiving objects:  85% (53608/63068), 4.36 MiB | 1.67 MiB/sReceiving objects:  97% (61176/63068), 4.36 MiB | 1.67 MiB/sReceiving objects:  99% (62438/63068), 4.36 MiB | 1.67 MiB/s\r\n",
+      "Receiving objects: 100% (63068/63068), 6.06 MiB | 2.03 MiB/s, done.\r\n",
       "Resolving deltas: 100% (60270/60270), done.\r\n",
       "\r\n",
       "Local identity for pyessv-archive set to \"Francis Charette Migneault <francis.charette.migneault@gmail.com>\"\r\n"
@@ -98,8 +105,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-27T22:13:02.695354212Z",
-     "start_time": "2023-09-27T22:12:55.413642180Z"
+     "end_time": "2023-09-28T16:31:16.902705889Z",
+     "start_time": "2023-09-28T16:31:11.106550733Z"
     }
    },
    "id": "f10d85e12b47da43"
@@ -112,7 +119,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2023-09-27 22:47:33.681584 [INFO] :: PYESSV :: Loading vocabularies from /home/francis/.esdoc/pyessv-archive ... please wait\n",
+      "2023-09-28 17:35:19.776139 [INFO] :: PYESSV :: Loading vocabularies from /home/francis/.esdoc/pyessv-archive ... please wait\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import tempfile\n",
+    "from datetime import datetime, date\n",
+    "from dateutil.parser import parse as dt_parse\n",
+    "from enum import Enum\n",
+    "\n",
+    "import numpy as np\n",
+    "import requests\n",
+    "import xncml\n",
+    "import pystac\n",
+    "from pystac.extensions import datacube\n",
+    "from pydantic.networks import Url\n",
+    "from shapely.geometry.polygon import Polygon\n",
+    "\n",
+    "import pyessv\n",
+    "pyessv.init()\n",
+    "\n",
+    "from STACpopulator.extensions import cmip6"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-28T17:35:20.176850296Z",
+     "start_time": "2023-09-28T17:35:19.792250122Z"
+    }
+   },
+   "id": "f68ea4339c5e4a9d"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
       "<ncml:netcdf xmlns:ncml=\"http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2\" location=\"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc\">\n",
       "  <ncml:attribute name=\"CCCma_model_hash\" value=\"fc4bb7db954c862d023b546e19aec6c588bc0552\" />\n",
@@ -299,25 +346,6 @@
     }
    ],
    "source": [
-    "import json\n",
-    "import tempfile\n",
-    "from datetime import datetime, date\n",
-    "from dateutil.parser import parse as dt_parse\n",
-    "from enum import Enum\n",
-    "\n",
-    "import numpy as np\n",
-    "import requests\n",
-    "import xncml\n",
-    "import pystac\n",
-    "from pystac.extensions import datacube\n",
-    "from pydantic.networks import Url\n",
-    "from shapely.geometry.polygon import Polygon\n",
-    "\n",
-    "import pyessv\n",
-    "pyessv.init()\n",
-    "\n",
-    "from STACpopulator.extensions import cmip6\n",
-    "\n",
     "# retrieve the file contents\n",
     "if not (input_ncml.startswith(\"/\") or input_ncml.startswith(\"file:///\")):\n",
     "    resp = requests.get(input_ncml, headers={\"Accept\": \"text/xml, application/xml\"}, timeout=5)\n",
@@ -334,26 +362,16 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-27T22:47:34.154049178Z",
-     "start_time": "2023-09-27T22:47:33.700947842Z"
+     "end_time": "2023-09-28T17:35:22.030164524Z",
+     "start_time": "2023-09-28T17:35:22.021956770Z"
     }
    },
    "id": "4fc2f66493dc56c5"
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/francis/dev/conda/envs/weaver/lib/python3.10/site-packages/xncml/core.py:482: UserWarning: Could not cast date:\n",
-      "'modified' is not a valid DataType\n",
-      "  warn(f\"Could not cast {attr['@name']}:\\n{exc}\")\n"
-     ]
-    }
-   ],
+   "execution_count": 18,
+   "outputs": [],
    "source": [
     "ds = xncml.Dataset(input_ncml)\n",
     "attrs = ds.to_cf_dict()\n",
@@ -431,8 +449,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-27T22:13:04.297953077Z",
-     "start_time": "2023-09-27T22:13:04.203138258Z"
+     "end_time": "2023-09-28T17:35:25.445079640Z",
+     "start_time": "2023-09-28T17:35:25.350961204Z"
     }
    },
    "id": "299946ccd58e2efc"
@@ -449,26 +467,248 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 19,
    "outputs": [
     {
-     "data": {
-      "text/plain": "{'type': 'Feature',\n 'stac_version': '1.0.0',\n 'id': 'test',\n 'properties': {'start_datetime': None,\n  'end_datetime': None,\n  'cube:dimensions': {'time': {'type': <DimensionType.TEMPORAL: 'temporal'>,\n    'length': 12},\n   'bnds': {'type': 'other', 'length': 2},\n   'vertices': {'type': 'other', 'length': 4},\n   'maxStrlen64': {'type': 'other', 'length': 64},\n   'j': {'type': <DimensionType.SPATIAL: 'spatial'>,\n    'length': 291,\n    'axis': 'y'},\n   'i': {'type': <DimensionType.SPATIAL: 'spatial'>,\n    'length': 360,\n    'axis': 'x'}},\n  'cube:variables': {'time': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['time'],\n    'unit': 'days since 1850-01-01'},\n   'j': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['j'],\n    'unit': '1'},\n   'i': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['i'],\n    'unit': '1'},\n   'time_bnds': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['time', 'bnds']},\n   'vertices_latitude': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['j', 'i', 'vertices']},\n   'vertices_longitude': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['j', 'i', 'vertices']},\n   'siconc': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['time', 'j', 'i'],\n    'unit': '%'},\n   'areacello': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['j', 'i'],\n    'unit': 'm2'},\n   'type': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['maxStrlen64']},\n   'latitude': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['j', 'i'],\n    'unit': 'degrees_north'},\n   'longitude': {'type': <VariableType.DATA: 'data'>,\n    'dimensions': ['j', 'i'],\n    'unit': 'degrees_east'}},\n  'datetime': None,\n  'Conventions': 'CF-1.7 CMIP-6.2',\n  'activity_id': 'ScenarioMIP',\n  'creation_date': datetime.datetime(2019, 9, 25, 23, 1, 33, tzinfo=TzInfo(UTC)),\n  'data_specs_version': '01.00.30',\n  'experiment': 'update of RCP4.5 based on SSP2',\n  'experiment_id': 'ssp245',\n  'frequency': 'mon',\n  'further_info_url': Url('https://furtherinfo.es-doc.org/CMIP6.CCCma.CanESM5.ssp245.none.r13i1p2f1'),\n  'grid_label': 'gn',\n  'institution': 'Canadian Centre for Climate Modelling and Analysis, Environment and Climate Change Canada, Victoria, BC V8P 5C2, Canada',\n  'institution_id': 'CCCma',\n  'nominal_resolution': '100 km',\n  'realm': ['seaIce'],\n  'source': 'CanESM5 (2019): \\naerosol: interactive\\natmos: CanAM5 (T63L49 native atmosphere, T63 Linear Gaussian Grid; 128 x 64 longitude/latitude; 49 levels; top level 1 hPa)\\natmosChem: specified oxidants for aerosols\\nland: CLASS3.6/CTEM1.2\\nlandIce: specified ice sheets\\nocean: NEMO3.4.1 (ORCA1 tripolar grid, 1 deg with refinement to 1/3 deg within 20 degrees of the equator; 361 x 290 longitude/latitude; 45 vertical levels; top grid cell 0-6.19 m)\\nocnBgchem: Canadian Model of Ocean Carbon (CMOC); NPZD ecosystem with OMIP prescribed carbonate chemistry\\nseaIce: LIM2',\n  'source_id': 'CanESM5',\n  'source_type': ['AOGCM'],\n  'sub_experiment': 'none',\n  'sub_experiment_id': 'none',\n  'table_id': 'SImon',\n  'variable_id': 'siconc',\n  'variant_label': 'r13i1p2f1',\n  'initialization_index': 1,\n  'physics_index': 2,\n  'realization_index': 13,\n  'forcing_index': 1,\n  'tracking_id': 'hdl:21.14100/9e4f804b-c161-44fa-acd1-c2e94e220c95',\n  'version': 'v20190429',\n  'product': 'model-output',\n  'license': 'CMIP6 model data produced by The Government of Canada (Canadian Centre for Climate Modelling and Analysis, Environment and Climate Change Canada) is licensed under a Creative Commons Attribution ShareAlike 4.0 International License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file) and at https:///pcmdi.llnl.gov/. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law.',\n  'grid': 'ORCA1 tripolar grid, 1 deg with refinement to 1/3 deg within 20 degrees of the equator; 361 x 290 longitude/latitude; 45 vertical levels; top grid cell 0-6.19 m',\n  'mip_era': 'CMIP6'},\n 'geometry': {'type': 'Polygon',\n  'coordinates': (((0.049800001084804535, 359.99493408203125),\n    (0.049800001084804535, 89.74176788330078),\n    (-78.39350128173828, 89.74176788330078),\n    (-78.39350128173828, 359.99493408203125),\n    (0.049800001084804535, 359.99493408203125)),)},\n 'links': [],\n 'assets': {'httpserver': {'href': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc'},\n  'opendap': {'href': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc'},\n  'wcs': {'href': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wcs/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc?service=WCS&version=1.0.0&request=GetCapabilities'},\n  'wms': {'href': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wms/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc?service=WMS&version=1.3.0&request=GetCapabilities'},\n  'nccs': {'href': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/ncss/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc/dataset.html'}},\n 'bbox': [0.0498, 359.99493, -78.3935, 89.74177],\n 'stac_extensions': ['https://stac-extensions.github.io/datacube/v2.0.0/schema.json',\n  'https://stac-extensions.github.io/cmip6/v1.0.0/schema.json']}"
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"type\": \"Feature\",\n",
+      "  \"stac_version\": \"1.0.0\",\n",
+      "  \"id\": \"test\",\n",
+      "  \"properties\": {\n",
+      "    \"start_datetime\": null,\n",
+      "    \"end_datetime\": null,\n",
+      "    \"cube:dimensions\": {\n",
+      "      \"time\": {\n",
+      "        \"type\": \"temporal\",\n",
+      "        \"length\": 12\n",
+      "      },\n",
+      "      \"bnds\": {\n",
+      "        \"type\": \"other\",\n",
+      "        \"length\": 2\n",
+      "      },\n",
+      "      \"vertices\": {\n",
+      "        \"type\": \"other\",\n",
+      "        \"length\": 4\n",
+      "      },\n",
+      "      \"maxStrlen64\": {\n",
+      "        \"type\": \"other\",\n",
+      "        \"length\": 64\n",
+      "      },\n",
+      "      \"j\": {\n",
+      "        \"type\": \"spatial\",\n",
+      "        \"length\": 291,\n",
+      "        \"axis\": \"y\"\n",
+      "      },\n",
+      "      \"i\": {\n",
+      "        \"type\": \"spatial\",\n",
+      "        \"length\": 360,\n",
+      "        \"axis\": \"x\"\n",
+      "      }\n",
+      "    },\n",
+      "    \"cube:variables\": {\n",
+      "      \"time\": {\n",
+      "        \"type\": \"data\",\n",
+      "        \"dimensions\": [\n",
+      "          \"time\"\n",
+      "        ],\n",
+      "        \"unit\": \"days since 1850-01-01\"\n",
+      "      },\n",
+      "      \"j\": {\n",
+      "        \"type\": \"data\",\n",
+      "        \"dimensions\": [\n",
+      "          \"j\"\n",
+      "        ],\n",
+      "        \"unit\": \"1\"\n",
+      "      },\n",
+      "      \"i\": {\n",
+      "        \"type\": \"data\",\n",
+      "        \"dimensions\": [\n",
+      "          \"i\"\n",
+      "        ],\n",
+      "        \"unit\": \"1\"\n",
+      "      },\n",
+      "      \"time_bnds\": {\n",
+      "        \"type\": \"data\",\n",
+      "        \"dimensions\": [\n",
+      "          \"time\",\n",
+      "          \"bnds\"\n",
+      "        ]\n",
+      "      },\n",
+      "      \"vertices_latitude\": {\n",
+      "        \"type\": \"data\",\n",
+      "        \"dimensions\": [\n",
+      "          \"j\",\n",
+      "          \"i\",\n",
+      "          \"vertices\"\n",
+      "        ]\n",
+      "      },\n",
+      "      \"vertices_longitude\": {\n",
+      "        \"type\": \"data\",\n",
+      "        \"dimensions\": [\n",
+      "          \"j\",\n",
+      "          \"i\",\n",
+      "          \"vertices\"\n",
+      "        ]\n",
+      "      },\n",
+      "      \"siconc\": {\n",
+      "        \"type\": \"data\",\n",
+      "        \"dimensions\": [\n",
+      "          \"time\",\n",
+      "          \"j\",\n",
+      "          \"i\"\n",
+      "        ],\n",
+      "        \"unit\": \"%\"\n",
+      "      },\n",
+      "      \"areacello\": {\n",
+      "        \"type\": \"data\",\n",
+      "        \"dimensions\": [\n",
+      "          \"j\",\n",
+      "          \"i\"\n",
+      "        ],\n",
+      "        \"unit\": \"m2\"\n",
+      "      },\n",
+      "      \"type\": {\n",
+      "        \"type\": \"data\",\n",
+      "        \"dimensions\": [\n",
+      "          \"maxStrlen64\"\n",
+      "        ]\n",
+      "      },\n",
+      "      \"latitude\": {\n",
+      "        \"type\": \"data\",\n",
+      "        \"dimensions\": [\n",
+      "          \"j\",\n",
+      "          \"i\"\n",
+      "        ],\n",
+      "        \"unit\": \"degrees_north\"\n",
+      "      },\n",
+      "      \"longitude\": {\n",
+      "        \"type\": \"data\",\n",
+      "        \"dimensions\": [\n",
+      "          \"j\",\n",
+      "          \"i\"\n",
+      "        ],\n",
+      "        \"unit\": \"degrees_east\"\n",
+      "      }\n",
+      "    },\n",
+      "    \"datetime\": null,\n",
+      "    \"Conventions\": \"CF-1.7 CMIP-6.2\",\n",
+      "    \"activity_id\": \"ScenarioMIP\",\n",
+      "    \"creation_date\": \"2019-09-25T23:01:33+00:00\",\n",
+      "    \"data_specs_version\": \"01.00.30\",\n",
+      "    \"experiment\": \"update of RCP4.5 based on SSP2\",\n",
+      "    \"experiment_id\": \"ssp245\",\n",
+      "    \"frequency\": \"mon\",\n",
+      "    \"further_info_url\": \"https://furtherinfo.es-doc.org/CMIP6.CCCma.CanESM5.ssp245.none.r13i1p2f1\",\n",
+      "    \"grid_label\": \"gn\",\n",
+      "    \"institution\": \"Canadian Centre for Climate Modelling and Analysis, Environment and Climate Change Canada, Victoria, BC V8P 5C2, Canada\",\n",
+      "    \"institution_id\": \"CCCma\",\n",
+      "    \"nominal_resolution\": \"100 km\",\n",
+      "    \"realm\": [\n",
+      "      \"seaIce\"\n",
+      "    ],\n",
+      "    \"source\": \"CanESM5 (2019): \\naerosol: interactive\\natmos: CanAM5 (T63L49 native atmosphere, T63 Linear Gaussian Grid; 128 x 64 longitude/latitude; 49 levels; top level 1 hPa)\\natmosChem: specified oxidants for aerosols\\nland: CLASS3.6/CTEM1.2\\nlandIce: specified ice sheets\\nocean: NEMO3.4.1 (ORCA1 tripolar grid, 1 deg with refinement to 1/3 deg within 20 degrees of the equator; 361 x 290 longitude/latitude; 45 vertical levels; top grid cell 0-6.19 m)\\nocnBgchem: Canadian Model of Ocean Carbon (CMOC); NPZD ecosystem with OMIP prescribed carbonate chemistry\\nseaIce: LIM2\",\n",
+      "    \"source_id\": \"CanESM5\",\n",
+      "    \"source_type\": [\n",
+      "      \"AOGCM\"\n",
+      "    ],\n",
+      "    \"sub_experiment\": \"none\",\n",
+      "    \"sub_experiment_id\": \"none\",\n",
+      "    \"table_id\": \"SImon\",\n",
+      "    \"variable_id\": \"siconc\",\n",
+      "    \"variant_label\": \"r13i1p2f1\",\n",
+      "    \"initialization_index\": 1,\n",
+      "    \"physics_index\": 2,\n",
+      "    \"realization_index\": 13,\n",
+      "    \"forcing_index\": 1,\n",
+      "    \"tracking_id\": \"hdl:21.14100/9e4f804b-c161-44fa-acd1-c2e94e220c95\",\n",
+      "    \"version\": \"v20190429\",\n",
+      "    \"product\": \"model-output\",\n",
+      "    \"license\": \"CMIP6 model data produced by The Government of Canada (Canadian Centre for Climate Modelling and Analysis, Environment and Climate Change Canada) is licensed under a Creative Commons Attribution ShareAlike 4.0 International License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file) and at https:///pcmdi.llnl.gov/. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law.\",\n",
+      "    \"grid\": \"ORCA1 tripolar grid, 1 deg with refinement to 1/3 deg within 20 degrees of the equator; 361 x 290 longitude/latitude; 45 vertical levels; top grid cell 0-6.19 m\",\n",
+      "    \"mip_era\": \"CMIP6\"\n",
+      "  },\n",
+      "  \"geometry\": {\n",
+      "    \"type\": \"Polygon\",\n",
+      "    \"coordinates\": [\n",
+      "      [\n",
+      "        [\n",
+      "          0.049800001084804535,\n",
+      "          359.99493408203125\n",
+      "        ],\n",
+      "        [\n",
+      "          0.049800001084804535,\n",
+      "          89.74176788330078\n",
+      "        ],\n",
+      "        [\n",
+      "          -78.39350128173828,\n",
+      "          89.74176788330078\n",
+      "        ],\n",
+      "        [\n",
+      "          -78.39350128173828,\n",
+      "          359.99493408203125\n",
+      "        ],\n",
+      "        [\n",
+      "          0.049800001084804535,\n",
+      "          359.99493408203125\n",
+      "        ]\n",
+      "      ]\n",
+      "    ]\n",
+      "  },\n",
+      "  \"links\": [],\n",
+      "  \"assets\": {\n",
+      "    \"httpserver\": {\n",
+      "      \"href\": \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc\"\n",
+      "    },\n",
+      "    \"opendap\": {\n",
+      "      \"href\": \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc\"\n",
+      "    },\n",
+      "    \"wcs\": {\n",
+      "      \"href\": \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wcs/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc?service=WCS&version=1.0.0&request=GetCapabilities\"\n",
+      "    },\n",
+      "    \"wms\": {\n",
+      "      \"href\": \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wms/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc?service=WMS&version=1.3.0&request=GetCapabilities\"\n",
+      "    },\n",
+      "    \"nccs\": {\n",
+      "      \"href\": \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/ncss/birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc/dataset.html\"\n",
+      "    }\n",
+      "  },\n",
+      "  \"bbox\": [\n",
+      "    0.049800001084804535,\n",
+      "    359.99493408203125,\n",
+      "    -78.39350128173828,\n",
+      "    89.74176788330078\n",
+      "  ],\n",
+      "  \"stac_extensions\": [\n",
+      "    \"https://stac-extensions.github.io/datacube/v2.0.0/schema.json\",\n",
+      "    \"https://stac-extensions.github.io/cmip6/v1.0.0/schema.json\"\n",
+      "  ]\n",
+      "}\n"
+     ]
     }
    ],
    "source": [
     "stac_item = item.to_dict()\n",
-    "stac_item"
+    "\n",
+    "def json_encode(obj):\n",
+    "    if isinstance(obj, (np.ndarray, np.number)):\n",
+    "        return obj.tolist()\n",
+    "    if isinstance(obj, (Url, Enum)):\n",
+    "        return str(obj)\n",
+    "    if isinstance(obj, (datetime, date)):\n",
+    "        return obj.isoformat()\n",
+    "    raise TypeError(f\"Type {type(obj)} not serializable\")\n",
+    "\n",
+    "stac_item_json = json.dumps(stac_item, default=json_encode, indent=2)\n",
+    "print(stac_item_json)"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-27T22:13:04.353755221Z",
-     "start_time": "2023-09-27T22:13:04.294777698Z"
+     "end_time": "2023-09-28T17:35:28.171687505Z",
+     "start_time": "2023-09-28T17:35:28.113990343Z"
     }
    },
    "id": "4eeb52c23edccb31"
@@ -485,18 +725,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "outputs": [],
    "source": [
-    "def json_encode(obj):\n",
-    "    if isinstance(obj, (np.ndarray, np.number)):\n",
-    "        return obj.tolist()\n",
-    "    if isinstance(obj, (Url, Enum)):\n",
-    "        return str(obj)\n",
-    "    if isinstance(obj, (datetime, date)):\n",
-    "        return obj.isoformat()\n",
-    "    raise TypeError(f\"Type {type(obj)} not serializable\")\n",
-    "\n",
     "# NOTE:\n",
     "#   It is important to define the expected file name with an explicit string as done below.\n",
     "#   This is to generate the corresponding glob pattern that will collect the output from the CWL execution.\n",
@@ -507,8 +738,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-27T22:47:38.832969763Z",
-     "start_time": "2023-09-27T22:47:38.710714517Z"
+     "end_time": "2023-09-28T17:06:28.432647458Z",
+     "start_time": "2023-09-28T17:06:28.386642425Z"
     }
    },
    "id": "e4fa98fcad8b5556"
@@ -516,21 +747,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "name": "conda-env-conda-weaver-py",
+   "name": "ncml2stac",
    "language": "python",
-   "display_name": "Python [conda env:conda-weaver]"
+   "display_name": "ncml2stac"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,8 +30,9 @@ nbqa
 parameterized
 pluggy>=0.7
 pytest
-pytest-rerunfailures
+pytest-cov
 pytest-notebook
+pytest-rerunfailures
 pycodestyle
 pydocstyle
 pylint>=2.15.4; python_version >= "3.7"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,11 +26,13 @@ flynt
 isort>=5
 mock<4
 mypy
+nbqa
 parameterized
 pluggy>=0.7
 pytest
 pytest-rerunfailures
 pytest-notebook
+pycodestyle
 pydocstyle
 pylint>=2.15.4; python_version >= "3.7"
 pylint-per-file-ignores; python_version >= "3.7"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,10 @@
 # --------------------------------
 # testing the README commands:
 # --------------------------------
+jupyter
 jupyter-repo2docker
-ipython2cwl
+ipython2cwl  # installs 'jupyter-repo2cwl'
+jinja2==3.0.3  # patch nbconvert (https://github.com/d2l-ai/d2l-book/issues/46)
 
 # ---------------------
 # General DevOps checks
@@ -28,6 +30,7 @@ parameterized
 pluggy>=0.7
 pytest
 pytest-rerunfailures
+pytest-notebook
 pydocstyle
 pylint>=2.15.4; python_version >= "3.7"
 pylint-per-file-ignores; python_version >= "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 -r requirements-sys.txt
-STACpopulator @ https://github.com/crim-ca/stac-populator/archive/refs/heads/weaver-repo2cwl-ncml2stac.zip
+# Following does not work
+# STACpopulator @ https://github.com/crim-ca/stac-populator/archive/refs/heads/weaver-repo2cwl-ncml2stac.zip
+# Also, editable '-e' required, otherwise module still not found...
+-e git+https://github.com/crim-ca/stac-populator@weaver-repo2cwl-ncml2stac#egg=STACpopulator
 xncml
 
 # extra requirements for notebook

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 -r requirements-sys.txt
 STACpopulator @ https://github.com/crim-ca/stac-populator/archive/refs/heads/weaver-repo2cwl-ncml2stac.zip
+xncml
+
+# extra requirements for notebook
+shapely

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,15 +32,22 @@ addopts =
 	--strict-markers
 	--tb=native
 	--ignore=tests/smoke
-	src/
+	--nb-test-files
 log_cli = false
-log_level = DEBUG
-python_files = test_*.py
+log_level = INFO
+python_files = test_*.py,notebooks/*
 markers = 
 	cli: mark test as related to CLI operations
+	notebooks: mark test as related to a Jupyter Notebook
 filterwarnings =
 	ignore:.*geojson\.org.*:urllib3.exceptions.InsecureRequestWarning
 	ignore:.*iana\.org.*:urllib3.exceptions.InsecureRequestWarning
+nb_diff_ignore =
+	/metadata
+	/cells/*/execution_count
+	/cells/4/outputs/0/text
+	/cells/5/outputs/0/text
+	/cells/7/outputs/0/text
 
 [isort]
 line_length = 120
@@ -98,7 +105,7 @@ add_select = D201,D213
 [coverage:run]
 branch = true
 source = ./
-include = src/*
+include = *
 omit = 
 	setup.py
 	docs/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ nb_diff_ignore =
 	/cells/*/execution_count
 	/cells/4/outputs/0/text
 	/cells/5/outputs/0/text
-	/cells/7/outputs/0/text
+	/cells/7/outputs/
 
 [isort]
 line_length = 120


### PR DESCRIPTION
## Changes

- Add CI utilities to test the Jupyter Notebook, build and deploy the resulting Docker image.
- Add CI configurations for tagging and defining various GitHub control flow tools.
- Remove irrelevant `Makefile` targets and add useful ones for this repository.
- Update `README` documentation with adjusted directive with real commands.
- Update `ncml2stac` notebook to display a valid STAC Item JSON as output.
- Fix Docker image generation causing `IndentError` due to `TYPE_CHECKING` directive only using `ipython2cwl` imports.